### PR TITLE
lsp周辺の仕様変更に対応した

### DIFF
--- a/lua/lazy/lazy.lua
+++ b/lua/lazy/lazy.lua
@@ -135,7 +135,6 @@ require("lazy").setup({
         event = "InsertEnter",
     },
     { "saadparwaiz1/cmp_luasnip", lazy = true, event = "InsertEnter" },
-    { "hrsh7th/cmp-copilot", lazy = true, event = "InsertEnter" },
 
     -- nvim-treesitter
     {

--- a/lua/lazy/lazy.lua
+++ b/lua/lazy/lazy.lua
@@ -98,11 +98,13 @@ require("lazy").setup({
     -- Simple plugins can be specified as strings
     { "rstacruz/vim-closer", lazy = true, event = "InsertEnter" },
 
-    -- LSP
     -- mason
-    { "williamboman/mason.nvim", lazy = true },
-    { "williamboman/mason-lspconfig.nvim", lazy = true, opt = {} },
-    { "neovim/nvim-lspconfig", lazy = true },
+    { "williamboman/mason.nvim" },
+
+    -- lsp
+    { "williamboman/mason-lspconfig.nvim" },
+    { "neovim/nvim-lspconfig" },
+
     {
         "jay-babu/mason-null-ls.nvim",
         lazy = true,
@@ -116,8 +118,6 @@ require("lazy").setup({
     { "hrsh7th/cmp-nvim-lsp", lazy = true },
     { "hrsh7th/cmp-buffer", lazy = true },
     { "hrsh7th/cmp-path", lazy = true },
-    { "hrsh7th/cmp-vsnip", lazy = true, event = "InsertEnter" },
-    { "hrsh7th/vim-vsnip", lazy = true, event = "InsertEnter" },
     {
         "zbirenbaum/copilot-cmp",
         lazy = true,
@@ -125,6 +125,17 @@ require("lazy").setup({
         opts = {},
     },
     { "hrsh7th/nvim-cmp", lazy = true, event = "InsertEnter" },
+    {
+        "L3MON4D3/LuaSnip",
+        -- follow latest release.
+        version = "v2.3", -- Replace <CurrentMajor> by the latest released major (first number of latest release)
+        -- install jsregexp (optional!).
+        build = "make install_jsregexp",
+        lazy = true,
+        event = "InsertEnter",
+    },
+    { "saadparwaiz1/cmp_luasnip", lazy = true, event = "InsertEnter" },
+    { "hrsh7th/cmp-copilot", lazy = true, event = "InsertEnter" },
 
     -- nvim-treesitter
     {

--- a/plugin/mason.lua
+++ b/plugin/mason.lua
@@ -1,3 +1,43 @@
+local capabilities = require("cmp_nvim_lsp").default_capabilities()
+
+require("lspconfig").lua_ls.setup({
+    capabilities = capabilities,
+    settings = {
+        Lua = {
+            runtime = {
+                version = "LuaJIT",
+            },
+            diagnostics = {
+                globals = { "vim" },
+            },
+            workspace = {
+                library = vim.list_extend(vim.api.nvim_get_runtime_file("lua", true), {
+                    "${3rd}/luv/library",
+                    "${3rd}/busted/library",
+                    "${3rd}/luassert/library",
+                }),
+                checkThirdParty = false,
+            },
+            telemetry = {
+                enable = false,
+            },
+        },
+    },
+})
+
+require("lspconfig").clangd.setup({
+    capabilities = capabilities,
+    settings = {
+        ["clangd"] = {
+            filetypes = { "c", "cpp", "objc", "objcpp" },
+            cmd = {
+                "clangd",
+                "--offset-encoding=utf-16",
+            },
+        },
+    },
+})
+
 require("mason").setup({
     ui = {
         icons = {
@@ -17,13 +57,13 @@ require("mason-lspconfig").setup({
         "jqls",
         "lua_ls",
         "marksman",
-        "pylsp",
         "sqls",
         "taplo",
         "ts_ls",
         "yamlls",
     },
     automatic_installation = true,
+    automatic_enable = true,
 })
 
 require("mason-nvim-dap").setup({
@@ -40,7 +80,6 @@ require("mason-nvim-dap").setup({
 require("mason-null-ls").setup({
     function() end,
     ensure_installed = {
-        -- "black",
         "biome",
         "cpplint",
         "clang-format",
@@ -50,7 +89,6 @@ require("mason-null-ls").setup({
         "hadolint",
         "markdownlint",
         "prettier",
-        -- "pylint",
         "stylua",
         "stylelint",
         "yamllint",
@@ -65,16 +103,10 @@ null_ls.setup({
         -- linters
         null_ls.builtins.diagnostics.hadolint,
         null_ls.builtins.diagnostics.yamllint,
-        -- null_ls.builtins.diagnostics.pylint.with({
-        --     diagnostics_postprocess = function(diagnostic)
-        --         diagnostic.code = diagnostic.message_id
-        --     end,
-        -- }),
         null_ls.builtins.diagnostics.hadolint,
 
         -- formatters
         null_ls.builtins.formatting.isort,
-        -- null_ls.builtins.formatting.black,
         null_ls.builtins.formatting.biome,
         null_ls.builtins.formatting.clang_format,
         null_ls.builtins.formatting.gofmt,

--- a/plugin/mason.lua
+++ b/plugin/mason.lua
@@ -13,83 +13,17 @@ require("mason-lspconfig").setup({
         "clangd",
         "dockerls",
         "docker_compose_language_service",
-        "graphql",
         "gopls",
         "jqls",
         "lua_ls",
         "marksman",
-        -- "rust_analyzer",
         "pylsp",
         "sqls",
         "taplo",
         "ts_ls",
         "yamlls",
     },
-})
-
-require("mason-lspconfig").setup_handlers({
-    function(server)
-        require("lspconfig")[server].setup({
-            capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol.make_client_capabilities()),
-        })
-    end,
-    -- ["rust_analyzer"] = function() end,
-    ["clangd"] = function()
-        require("lspconfig").clangd.setup({
-            capabilities = require("cmp_nvim_lsp").default_capabilities(),
-            cmd = {
-                "clangd",
-                "--offset-encoding=utf-16",
-            },
-        })
-        -- require("clangd_extensions.inlay_hints").setup_autocmd()
-        -- require("clangd_extensions.inlay_hints").set_inlay_hints()
-    end,
-    ["pylsp"] = function()
-        require("lspconfig").pylsp.setup({
-            settings = {
-                pylsp = {
-                    plugins = {
-                        pycodestyle = {
-                            ignore = { "W391", "E713" },
-                            maxLineLength = 120,
-                        },
-                        pylint = {
-                            enabled = true,
-                            args = {
-                                "--disable=C0114,C0115,C0116,C0301",
-                            },
-                        },
-                        black = {
-                            lineLength = 120,
-                        },
-                        flake8 = {
-                            ignore = { "W391" },
-                            maxLineLength = 120,
-                        },
-                    },
-                },
-            },
-        })
-    end,
-    ["gopls"] = function()
-        require("lspconfig").gopls.setup({
-            analyzes = {
-                unusedparams = true,
-            },
-            staticcheck = true,
-            gofumpt = true,
-        })
-    end,
-    ["taplo"] = function()
-        require("lspconfig").taplo.setup({
-            settings = {
-                taplo = {
-                    checkOnSave = true,
-                },
-            },
-        })
-    end,
+    automatic_installation = true,
 })
 
 require("mason-nvim-dap").setup({
@@ -100,7 +34,7 @@ require("mason-nvim-dap").setup({
         "codelldb",
         "cpptools",
     },
-    handlers = {},
+    automatic_installation = true,
 })
 
 require("mason-null-ls").setup({
@@ -122,7 +56,7 @@ require("mason-null-ls").setup({
         "yamllint",
         "yamlfmt",
     },
-    handlers = {},
+    automatic_installation = true,
 })
 
 local null_ls = require("null-ls")

--- a/plugin/nvim-cmp.lua
+++ b/plugin/nvim-cmp.lua
@@ -4,8 +4,7 @@ cmp.setup({
     snippet = {
         -- REQUIRED - you must specify a snippet engine
         expand = function(args)
-            vim.fn["vsnip#anonymous"](args.body) -- For `vsnip` users.
-            -- vim.snippet.expand(args.body) -- For native neovim snippets (Neovim v0.10+)
+            require("luasnip").lsp_expand(args.body) -- For `luasnip` users.
         end,
     },
     window = {
@@ -21,9 +20,8 @@ cmp.setup({
     }),
     sources = cmp.config.sources({
         { name = "nvim_lsp", group_index = 2 },
-        -- { name = "luasnip", group_index = 2 }, -- For luasnip users.
+        { name = "luasnip", group_index = 2 }, -- For luasnip users.
         { name = "copilot", group_index = 2 }, -- For copilot users.
-        { name = "vsnip", group_index = 2 }, -- For vsnip users.
         { name = "path" },
     }, {
         { name = "buffer" },
@@ -48,3 +46,4 @@ cmp.setup.cmdline(":", {
     }),
     matching = { disallow_symbol_nonprefix_matching = false },
 })
+

--- a/plugin/nvim-lspconfig.lua
+++ b/plugin/nvim-lspconfig.lua
@@ -1,7 +1,7 @@
 local capabilities = require("cmp_nvim_lsp").default_capabilities()
 
--- vim.lsp.enable("pylsp")
-vim.lsp.config("pylsp", {
+require("lspconfig").pylsp.setup({
+    capabilities = capabilities,
     settings = {
         pylsp = {
             plugins = {
@@ -26,52 +26,4 @@ vim.lsp.config("pylsp", {
         },
     },
 })
-require("lspconfig").pylsp.setup({
-    capabilities = capabilities,
-    -- other lspconfig configs
-})
 
--- vim.lsp.enable("lua_ls")
-vim.lsp.config("lua_ls", {
-    settings = {
-        Lua = {
-            runtime = {
-                version = "LuaJIT",
-            },
-            diagnostics = {
-                globals = { "vim" },
-            },
-            workspace = {
-                library = vim.list_extend(vim.api.nvim_get_runtime_file("lua", true), {
-                    "${3rd}/luv/library",
-                    "${3rd}/busted/library",
-                    "${3rd}/luassert/library",
-                }),
-                checkThirdParty = false,
-            },
-            telemetry = {
-                enable = false,
-            },
-        },
-    },
-})
-require("lspconfig").lua_ls.setup({
-    capabilities = capabilities,
-    -- other lspconfig configs
-})
-
-vim.lsp.config("clangd", {
-    settings = {
-        ["clangd"] = {
-            filetypes = { "c", "cpp", "objc", "objcpp" },
-            cmd = {
-                "clangd",
-                "--offset-encoding=utf-16",
-            },
-        },
-    },
-})
-require("lspconfig").clangd.setup({
-    capabilities = capabilities,
-    -- other lspconfig configs
-})

--- a/plugin/nvim-lspconfig.lua
+++ b/plugin/nvim-lspconfig.lua
@@ -1,0 +1,77 @@
+local capabilities = require("cmp_nvim_lsp").default_capabilities()
+
+-- vim.lsp.enable("pylsp")
+vim.lsp.config("pylsp", {
+    settings = {
+        pylsp = {
+            plugins = {
+                pycodestyle = {
+                    ignore = { "W391", "E713" },
+                    maxLineLength = 120,
+                },
+                pylint = {
+                    enabled = true,
+                    args = {
+                        "--disable=C0114,C0115,C0116,C0301,E401",
+                    },
+                },
+                black = {
+                    lineLength = 120,
+                },
+                flake8 = {
+                    ignore = { "W391", "E203", "E701", "F401", "W503", "E401", "E402" },
+                    maxLineLength = 120,
+                },
+            },
+        },
+    },
+})
+require("lspconfig").pylsp.setup({
+    capabilities = capabilities,
+    -- other lspconfig configs
+})
+
+-- vim.lsp.enable("lua_ls")
+vim.lsp.config("lua_ls", {
+    settings = {
+        Lua = {
+            runtime = {
+                version = "LuaJIT",
+            },
+            diagnostics = {
+                globals = { "vim" },
+            },
+            workspace = {
+                library = vim.list_extend(vim.api.nvim_get_runtime_file("lua", true), {
+                    "${3rd}/luv/library",
+                    "${3rd}/busted/library",
+                    "${3rd}/luassert/library",
+                }),
+                checkThirdParty = false,
+            },
+            telemetry = {
+                enable = false,
+            },
+        },
+    },
+})
+require("lspconfig").lua_ls.setup({
+    capabilities = capabilities,
+    -- other lspconfig configs
+})
+
+vim.lsp.config("clangd", {
+    settings = {
+        ["clangd"] = {
+            filetypes = { "c", "cpp", "objc", "objcpp" },
+            cmd = {
+                "clangd",
+                "--offset-encoding=utf-16",
+            },
+        },
+    },
+})
+require("lspconfig").clangd.setup({
+    capabilities = capabilities,
+    -- other lspconfig configs
+})


### PR DESCRIPTION
This pull request introduces significant updates to the Neovim configuration, focusing on improving LSP (Language Server Protocol) support, transitioning to `LuaSnip` for snippets, and simplifying the plugin setup process. The changes include adding new plugins, modifying LSP configurations, and replacing deprecated or unused features.

### LSP and Plugin Configuration Updates:
* **Streamlined LSP Setup**: Removed redundant handlers and added direct configurations for `lua_ls`, `clangd`, and `pylsp` in `plugin/mason.lua` and `plugin/nvim-lspconfig.lua`. This simplifies the LSP setup and improves maintainability. [[1]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aR1-R40) [[2]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aL16-R66) [[3]](diffhunk://#diff-604a49ceef812bda4b86dd695e07f31be94a126d53d97c0971c8cca01a547044R1-R29)
* **Automatic Installation**: Enabled `automatic_installation` and `automatic_enable` for `mason-lspconfig`, `mason-nvim-dap`, and `mason-null-ls` to automate the installation and activation of tools. [[1]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aL16-R66) [[2]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aL103-L109) [[3]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aL119-R97)

### Snippet Engine Transition:
* **Switch to `LuaSnip`**: Replaced `vsnip` with `LuaSnip` as the snippet engine in `plugin/nvim-cmp.lua`. Updated the snippet expansion logic and added `cmp_luasnip` to the plugin list. [[1]](diffhunk://#diff-c92d64d61602477b12857ad41faf3489e450ae2b46d2818cacc324ed6d0dda29L119-R137) [[2]](diffhunk://#diff-98fefa11cbd59302bab88da40238b2bd4ac4469c5e444c51887527f05f3e3496L7-R7) [[3]](diffhunk://#diff-98fefa11cbd59302bab88da40238b2bd4ac4469c5e444c51887527f05f3e3496L24-L26)

### Plugin Additions and Removals:
* **New Plugins**: Added `LuaSnip` and `cmp_luasnip` for snippet support, along with their configurations.
* **Removed Deprecated Plugins**: Removed `vsnip` and its related plugins (`cmp-vsnip` and `vim-vsnip`) from the configuration. [[1]](diffhunk://#diff-c92d64d61602477b12857ad41faf3489e450ae2b46d2818cacc324ed6d0dda29L119-R137) [[2]](diffhunk://#diff-98fefa11cbd59302bab88da40238b2bd4ac4469c5e444c51887527f05f3e3496L24-L26)

### Cleanup and Optimization:
* **Removed Unused Linters and Formatters**: Deprecated tools like `pylint` and `black` were removed from the `null-ls` setup to streamline the configuration. [[1]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aL119-R97) [[2]](diffhunk://#diff-b3100f80b5e1529364e86f1677dfc7219cefbd77c14988c0b2c0d804eed4e20aL134-L143)
* **Simplified Plugin Loading**: Adjusted lazy loading settings for certain plugins to ensure proper initialization during events like `InsertEnter`.

These changes collectively enhance the Neovim setup by improving usability, reducing redundancy, and transitioning to more modern and efficient tools.