### PR TITLE
feat: avante.nvimとcopilot-cmpのプラグイン設定を削除

### DIFF
--- a/lua/lazy/lazy.lua
+++ b/lua/lazy/lazy.lua
@@ -23,71 +23,6 @@ require("lazy").setup({
         },
     },
 
-    -- avante
-    {
-        "yetone/avante.nvim",
-        event = "VeryLazy",
-        lazy = false,
-        version = false, -- Set this to "*" to always pull the latest release version, or set it to false to update to the latest code changes.
-        opts = {
-            ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "cohere" | "copilot" | string
-            provider = "claude", -- The provider used in Aider mode or in the planning phase of Cursor Planning Mode
-            -- WARNING: Since auto-suggestions are a high-frequency operation and therefore expensive,
-            -- currently designating it as `copilot` provider is dangerous because: https://github.com/yetone/avante.nvim/issues/1048
-            -- Of course, you can reduce the request frequency by increasing `suggestion.debounce`.
-            -- add any opts here
-            auto_suggestions_provider = "claude",
-            cursor_applying_provider = nil, -- The provider used in the applying phase of Cursor Planning Mode, defaults to nil, when nil uses Config.provider as the provider for the applying phase
-            claude = {
-                endpoint = "https://api.anthropic.com",
-                model = "claude-3-5-sonnet-20241022",
-                temperature = 0,
-                max_tokens = 4096,
-            },
-        },
-        -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
-        build = "make",
-        -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
-        dependencies = {
-            "nvim-treesitter/nvim-treesitter",
-            "stevearc/dressing.nvim",
-            "nvim-lua/plenary.nvim",
-            "MunifTanjim/nui.nvim",
-            --- The below dependencies are optional,
-            "echasnovski/mini.pick", -- for file_selector provider mini.pick
-            "nvim-telescope/telescope.nvim", -- for file_selector provider telescope
-            "hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
-            "ibhagwan/fzf-lua", -- for file_selector provider fzf
-            "nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
-            "zbirenbaum/copilot.lua", -- for providers='copilot'
-            {
-                -- support for image pasting
-                "HakonHarnes/img-clip.nvim",
-                event = "VeryLazy",
-                opts = {
-                    -- recommended settings
-                    default = {
-                        embed_image_as_base64 = false,
-                        prompt_for_file_name = false,
-                        drag_and_drop = {
-                            insert_mode = true,
-                        },
-                        -- required for Windows users
-                        use_absolute_path = true,
-                    },
-                },
-            },
-            {
-                -- Make sure to set this up properly if you have lazy=true
-                "MeanderingProgrammer/render-markdown.nvim",
-                opts = {
-                    file_types = { "markdown", "Avante" },
-                },
-                ft = { "markdown", "Avante" },
-            },
-        },
-    },
-
     -- Git
     {
         "tpope/vim-fugitive",
@@ -118,12 +53,6 @@ require("lazy").setup({
     { "hrsh7th/cmp-nvim-lsp", lazy = true },
     { "hrsh7th/cmp-buffer", lazy = true },
     { "hrsh7th/cmp-path", lazy = true },
-    {
-        "zbirenbaum/copilot-cmp",
-        lazy = true,
-        event = "InsertEnter",
-        opts = {},
-    },
     { "hrsh7th/nvim-cmp", lazy = true, event = "InsertEnter" },
     {
         "L3MON4D3/LuaSnip",


### PR DESCRIPTION
avante.nvimおよび関連依存プラグインの設定を削除しました。
また、copilot-cmpの設定も削除しました。これにより不要な
プラグインの読み込みを防ぎ、設定ファイルを簡素化します。